### PR TITLE
feat: multi-stage Dockerfile with prod + worker targets

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM dunglas/frankenphp:1-php8.3 AS frankenphp_upstream
 
+### Base (extensions PHP, paquets système, user) ###
 FROM frankenphp_upstream AS frankenphp_base
 
 WORKDIR /app
@@ -7,7 +8,8 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     vim \
 	acl \
-#    supervisor \
+    supervisor \
+    procps \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Create non-root user with configurable UID/GID
@@ -18,31 +20,87 @@ RUN groupadd -g ${GROUP_ID} www && \
     useradd -u ${USER_ID} -g www -m -s /bin/bash www && \
     chown -R www:www /app /data /config
 
-# add additional extensions here:
+# Extensions PHP
 RUN install-php-extensions \
     @composer \
 	intl \
 	zip \
 	opcache \
-    apcu
-#	pdo_pgsql \
-#    pcntl \
-#    bcmath \
-#    amqp
+    apcu \
+	pdo_pgsql \
+    pcntl
+
+# Config PHP commune dev+prod
+COPY --link .docker/php/app.ini $PHP_INI_DIR/conf.d/
 
 ENV COMPOSER_HOME=/home/www/.composer
-# https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 HEALTHCHECK --start-period=60s CMD curl -f http://localhost:2019/metrics || exit 1
 CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile" ]
 
-# Dev Image
+### Dev Image ###
 FROM frankenphp_base AS frankenphp_dev
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
-# Switch to non-root user
 USER www
 
 CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
+
+### Worker Dev Image ###
+FROM frankenphp_dev AS frankenphp_worker_dev
+COPY --link ./.docker/supervisor.d /etc/supervisor
+HEALTHCHECK --start-period=10s --interval=30s --timeout=10s --retries=3 \
+  CMD pgrep -f "messenger:consume" > /dev/null || exit 1
+CMD ["/usr/bin/supervisord"]
+
+### Composer deps stage ###
+FROM frankenphp_base AS composer_deps
+WORKDIR /app
+COPY composer.* symfony.* ./
+RUN set -eux; \
+	composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
+
+### Prod Image ###
+FROM frankenphp_base AS frankenphp_prod
+ENV APP_ENV=prod
+
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+# Tuning OPcache prod
+COPY --link .docker/php/app.prod.ini $PHP_INI_DIR/conf.d/
+
+# Caddyfile baked dans l'image (en dev il est monté en volume pour live edit)
+COPY --link .docker/franken/Caddyfile /etc/caddy/Caddyfile
+
+# Vendor composer pré-installé (couche cache séparée)
+COPY --from=composer_deps /app/vendor ./vendor
+COPY --link composer.* symfony.* ./
+
+# Sources app
+COPY --link . ./
+
+# Nettoyage des fichiers inutiles en prod
+RUN rm -rf .docker .github node_modules .git assets
+
+# Génération autoload optimisée + post-install (cache:clear, assets:install)
+RUN set -eux; \
+	mkdir -p var/cache var/log; \
+	composer dump-autoload --classmap-authoritative --no-dev; \
+	composer run-script --no-dev post-install-cmd; \
+	chmod +x bin/console; \
+	chown -R www:www var public 2>/dev/null || true; \
+	sync
+
+USER www
+
+### Worker Prod Image ###
+FROM frankenphp_prod AS frankenphp_worker_prod
+COPY --link ./.docker/supervisor.d /etc/supervisor
+HEALTHCHECK --start-period=10s --interval=30s --timeout=10s --retries=3 \
+  CMD pgrep -f "messenger:consume" > /dev/null || exit 1
+CMD ["/usr/bin/supervisord"]

--- a/.docker/php/app.ini
+++ b/.docker/php/app.ini
@@ -1,0 +1,20 @@
+; Config PHP partagée dev + prod (chargée via $PHP_INI_DIR/conf.d/)
+
+expose_php = 0
+date.timezone = Europe/Paris
+
+; Realpath cache pour FrankenPHP (worker mode)
+; https://symfony.com/doc/current/performance.html
+realpath_cache_size = 4096K
+realpath_cache_ttl = 600
+
+; APCu en CLI (Symfony cache utilise APCu)
+apc.enable_cli = 1
+
+; Session : protection fixation
+session.use_strict_mode = 1
+
+; Limites upload
+upload_max_filesize = 50M
+post_max_size = 100M
+memory_limit = 256M

--- a/.docker/php/app.prod.ini
+++ b/.docker/php/app.prod.ini
@@ -1,0 +1,8 @@
+; Tuning OPcache prod uniquement
+; https://symfony.com/doc/current/performance.html
+
+opcache.interned_strings_buffer = 16
+opcache.max_accelerated_files = 20000
+opcache.memory_consumption = 256
+opcache.enable_file_override = 1
+opcache.validate_timestamps = 0

--- a/.docker/supervisor.d/conf.d/messenger-consume.conf
+++ b/.docker/supervisor.d/conf.d/messenger-consume.conf
@@ -1,0 +1,13 @@
+[program:messenger-consume]
+command=php /app/bin/console messenger:consume async --time-limit=3600 --memory-limit=512M
+user=www
+numprocs=1
+startsecs=1
+autostart=true
+autorestart=true
+stopwaitsecs=10
+process_name=%(program_name)s_%(process_num)02d
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/.docker/supervisor.d/supervisord.conf
+++ b/.docker/supervisor.d/supervisord.conf
@@ -1,0 +1,20 @@
+[supervisord]
+nodaemon=true
+user=www
+logfile=/dev/stdout
+logfile_maxbytes=0
+loglevel=info
+pidfile=/tmp/supervisord.pid
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[include]
+files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
## Summary
- Refactored Dockerfile with 6 build targets: base, dev, worker_dev, composer_deps, prod, worker_prod
- Added `.docker/php/app.ini` for shared PHP config (timezone, realpath cache, APCu, upload limits)
- Added `.docker/php/app.prod.ini` for OPcache production tuning
- Added `.docker/supervisor.d/` for Symfony Messenger async worker management
- Production image: classmap-authoritative autoloader, no dev files, OPcache optimized

## Test plan
- [ ] `docker compose build` still works for dev target
- [ ] `docker compose build --build-arg target=frankenphp_prod` builds the prod image
- [ ] Worker target starts supervisor correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)