### PR TITLE
feat: enable PostgreSQL service with healthcheck

### DIFF
--- a/castor.php
+++ b/castor.php
@@ -1,14 +1,35 @@
 <?php
 
 use Castor\Attribute\AsContext;
+use Castor\Attribute\AsTask;
 use Castor\Context;
 
 use function Castor\import;
+use function Castor\variable;
+use function Castor\wait_for_docker_container;
 
 #[AsContext(name: 'my_context', default: true)]
 function my_context(): Context
 {
     return new Context(environment: ['STACK_NAME' => 'starter']);
+}
+
+#[AsTask('wait-php-container')]
+function waitPhpContainer(): void
+{
+    wait_for_docker_container(
+        containerName: variable('STACK_NAME') . '_php',
+        message: 'Waiting for PHP container to be ready...',
+    );
+}
+
+#[AsTask('wait-db-container')]
+function waitDbContainer(): void
+{
+    wait_for_docker_container(
+        containerName: variable('STACK_NAME') . '_db',
+        message: 'Waiting for DB container to be ready...',
+    );
 }
 
 import('make/castor_entrypoint.php');

--- a/castor.php
+++ b/castor.php
@@ -4,8 +4,9 @@ use Castor\Attribute\AsContext;
 use Castor\Attribute\AsTask;
 use Castor\Context;
 
+use function Castor\context;
 use function Castor\import;
-use function Castor\variable;
+use function Castor\io;
 use function Castor\wait_for_docker_container;
 
 #[AsContext(name: 'my_context', default: true)]
@@ -17,19 +18,29 @@ function my_context(): Context
 #[AsTask('wait-php-container')]
 function waitPhpContainer(): void
 {
+    $stackName = context()->environment['STACK_NAME'];
+    $containerName = "{$stackName}_php";
+
     wait_for_docker_container(
-        containerName: variable('STACK_NAME') . '_php',
-        message: 'Waiting for PHP container to be ready...',
+        containerName: $containerName,
+        message: "Waiting for {$containerName} to be ready...",
     );
+
+    io()->success('PHP container is ready!');
 }
 
 #[AsTask('wait-db-container')]
 function waitDbContainer(): void
 {
+    $stackName = context()->environment['STACK_NAME'];
+    $containerName = "{$stackName}_db";
+
     wait_for_docker_container(
-        containerName: variable('STACK_NAME') . '_db',
-        message: 'Waiting for DB container to be ready...',
+        containerName: $containerName,
+        message: "Waiting for {$containerName} to be ready...",
     );
+
+    io()->success('DB container is ready!');
 }
 
 import('make/castor_entrypoint.php');

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,6 +4,11 @@ services:
         ports:
             - "8081:80"
 
+    db:
+        container_name: starter_db
+
 networks:
     traefik_traefik_proxy:
         external: false
+    starter_internal:
+        driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
                 GROUP_ID: ${GROUP_ID:-1000}
         environment:
             SERVER_NAME: ":80"
+            TZ: Europe/Paris
         volumes:
             - ./:/app
             - ./.docker/franken/Caddyfile:/etc/caddy/Caddyfile
@@ -32,24 +33,31 @@ services:
                 - traefik.http.routers.starter-secure.tls=true
         networks:
             - traefik_traefik_proxy
-#            - starter_internal
+            - starter_internal
 
-#    db:
-#        image: postgres:16
-#        environment:
-#            POSTGRES_PASSWORD: root
-#        volumes:
-#            - starter_db_data:/var/lib/postgresql/data:rw
-#        networks:
-#            - starter_internal
+    db:
+        image: postgres:18
+        environment:
+            POSTGRES_PASSWORD: root
+            TZ: Europe/Paris
+            PGTZ: Europe/Paris
+        volumes:
+            - starter_db_data:/var/lib/postgresql:rw
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+        networks:
+            - starter_internal
 
 volumes:
     starter_caddy_data:
     starter_caddy_config:
-#    starter_db_data:
+    starter_db_data:
 
 networks:
     traefik_traefik_proxy:
         external: true
-#    starter_internal:
-#        driver: overlay
+    starter_internal:
+        driver: overlay


### PR DESCRIPTION
## Summary
- Enable PostgreSQL 18 as default database service (was commented out)
- Add healthcheck (`pg_isready`) for proper startup ordering
- Add timezone config (`TZ`/`PGTZ`) to all services
- Add `starter_internal` overlay network for service isolation
- Update CI compose with DB container name + bridge network
- Add `wait-php-container` and `wait-db-container` Castor tasks

## Test plan
- [ ] `docker compose up` starts both PHP and PostgreSQL
- [ ] `castor barlito:castor:wait-db-container` waits for DB readiness
- [ ] CI workflow can use the DB service

🤖 Generated with [Claude Code](https://claude.com/claude-code)