### PR TITLE
feat: add PHPStan static analysis at level 6

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: 6
+    paths:
+        - src/
+    excludePaths:
+        - src/Kernel.php


### PR DESCRIPTION
## Summary
- Add `phpstan.dist.neon` configuration at level 6 (strict typing)
- Add `make phpstan` rule with 512MB memory limit for large projects
- Add `make phpstan.install` to bootstrap PHPStan + extensions (symfony, doctrine)
- Add `make quality` aggregate target running all checks in sequence

## Test plan
- [ ] `make phpstan.install` installs PHPStan correctly
- [ ] `make phpstan` runs analysis on src/
- [ ] `make quality` chains all checks (cs_fixer.dry_run + phpcs + phpmd + phpstan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)