### PR TITLE
feat: add release workflow + Trivy image security scanning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build & Push Main Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .docker/Dockerfile
+          target: frankenphp_prod
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:${{ github.ref_name }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:latest
+          build-args: |
+            APP_VERSION=${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:buildcache,mode=max
+
+      - name: Build & Push Worker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .docker/Dockerfile
+          target: frankenphp_worker_prod
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}-worker:${{ github.ref_name }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}-worker:latest
+          build-args: |
+            APP_VERSION=${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:buildcache

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,41 @@
+name: Security Scan
+
+on:
+  workflow_call:
+  schedule:
+    - cron: '0 6 * * 1'
+
+jobs:
+
+  trivy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Build image for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .docker/Dockerfile
+          target: frankenphp_prod
+          push: false
+          load: true
+          tags: local/starter:scan
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'local/starter:scan'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+
+      - name: Upload Trivy scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- **Release workflow** (`release.yaml`): triggered on GitHub release publish
  - Builds & pushes main + worker Docker images to Docker Hub
  - Uses Buildx with registry-level cache (`:buildcache` tag)
  - Dynamic image naming from `github.event.repository.name`
  - `APP_VERSION` build arg injected from git tag

- **Security scan workflow** (`security.yaml`): Trivy vulnerability scanner
  - Builds prod image locally and scans for CRITICAL + HIGH severity
  - Callable as reusable workflow (`workflow_call`) for CI integration
  - Weekly cron schedule (Monday 6 AM) for ongoing monitoring
  - Uploads SARIF results to GitHub Security tab
  - **Fails CI** if critical/high vulnerabilities found

## Test plan
- [ ] Create a GitHub release → images pushed to Docker Hub
- [ ] Trivy scan runs and uploads results to Security tab
- [ ] CI fails if CRITICAL/HIGH vulns are present in the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)