### PR TITLE
feat: add deploy workflow with rolling update strategy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,10 @@ name: Deploy
 on:
   workflow_dispatch:
     inputs:
+      tag:
+        description: "Image tag to deploy (defaults to current branch/tag)"
+        required: false
+        type: string
       re-deploy:
         description: "Full re-deploy (undeploy + redeploy) instead of rolling update"
         required: true
@@ -17,6 +21,7 @@ jobs:
       DOCKER_HOST: ssh://${{ vars.SERVER_USERNAME }}@${{ vars.SERVER_HOST }}:${{ vars.SERVER_PORT }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       APP_SECRET: ${{ secrets.APP_SECRET }}
+      DEPLOY_TAG: ${{ inputs.tag || github.ref_name }}
 
     steps:
       - uses: actions/checkout@v6
@@ -43,19 +48,32 @@ jobs:
         if: inputs.re-deploy
         run: |
           make undeploy || true
-          TAG=$GITHUB_REF_NAME make deploy.prod
+          TAG=$DEPLOY_TAG make deploy.prod
 
-      - name: Update main service
+      - name: Backup database
         if: ${{ ! inputs.re-deploy }}
+        run: make db.backup
+
+      - name: Drain worker
+        if: ${{ ! inputs.re-deploy }}
+        run: docker service scale ${STACK_NAME:-starter}_message_worker=0 || true
+
+      - name: Update main service + migrate
+        if: ${{ ! inputs.re-deploy }}
+        env:
+          STACK_NAME: starter
         run: |
-          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:$GITHUB_REF_NAME starter_php"
+          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:$DEPLOY_TAG ${STACK_NAME}_php"
           castor barlito:castor:wait-php-container
           make doctrine.migrate
 
-      - name: Update worker service
+      - name: Update & restart worker
         if: ${{ ! inputs.re-deploy }}
+        env:
+          STACK_NAME: starter
         run: |
-          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}-worker:$GITHUB_REF_NAME starter_message_worker"
+          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}-worker:$DEPLOY_TAG ${STACK_NAME}_message_worker"
+          docker service scale ${STACK_NAME}_message_worker=1
 
       - name: Smoke test
         run: make smoke.test

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,61 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      re-deploy:
+        description: "Full re-deploy (undeploy + redeploy) instead of rolling update"
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      DOCKER_HOST: ssh://${{ vars.SERVER_USERNAME }}@${{ vars.SERVER_HOST }}:${{ vars.SERVER_PORT }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      APP_SECRET: ${{ secrets.APP_SECRET }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Setup castor
+        uses: castor-php/setup-castor@v1.0.0
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p ${{ vars.SERVER_PORT }} ${{ vars.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Re-Deploy Stack
+        if: inputs.re-deploy
+        run: |
+          make undeploy || true
+          TAG=$GITHUB_REF_NAME make deploy.prod
+
+      - name: Update main service
+        if: ${{ ! inputs.re-deploy }}
+        run: |
+          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:$GITHUB_REF_NAME starter_php"
+          castor barlito:castor:wait-php-container
+          make doctrine.migrate
+
+      - name: Update worker service
+        if: ${{ ! inputs.re-deploy }}
+        run: |
+          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}-worker:$GITHUB_REF_NAME starter_message_worker"
+
+      - name: Smoke test
+        run: make smoke.test

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -7,10 +7,11 @@ on:
         description: "Image tag to rollback to (e.g. v1.2.0)"
         required: true
         type: string
-      migration-version:
-        description: "Doctrine migration version to rollback to (e.g. DoctrineMigrations\\Version20240101120000). Leave empty to skip migration rollback."
-        required: false
-        type: string
+      skip-migration-rollback:
+        description: "Skip automatic migration rollback (if no schema changes between versions)"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   rollback:
@@ -26,6 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'true'
+          fetch-depth: 0
 
       - name: Setup castor
         uses: castor-php/setup-castor@v1.0.0
@@ -43,15 +45,57 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Detect migration version to rollback to
+        if: ${{ ! inputs.skip-migration-rollback }}
+        id: detect-migration
+        run: |
+          TARGET_TAG="${{ inputs.tag }}"
+
+          # List migration files present in the target tag
+          TARGET_MIGRATIONS=$(git ls-tree -r --name-only "$TARGET_TAG" -- migrations/ 2>/dev/null | grep 'Version' | sort)
+
+          if [ -z "$TARGET_MIGRATIONS" ]; then
+            echo "No migrations found in target tag $TARGET_TAG"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # List current migration files
+          CURRENT_MIGRATIONS=$(find migrations/ -name 'Version*.php' 2>/dev/null | sort)
+
+          # Find migrations that exist now but NOT in the target tag (added after target)
+          NEW_MIGRATIONS=$(comm -23 <(echo "$CURRENT_MIGRATIONS") <(echo "$TARGET_MIGRATIONS"))
+
+          if [ -z "$NEW_MIGRATIONS" ]; then
+            echo "No new migrations since $TARGET_TAG — no rollback needed"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Migrations added since $TARGET_TAG:"
+          echo "$NEW_MIGRATIONS"
+
+          # The target version is the latest migration that EXISTS in the target tag
+          LATEST_TARGET=$(echo "$TARGET_MIGRATIONS" | tail -1)
+          # Extract class name from filename: migrations/Version20240101120000.php → DoctrineMigrations\Version20240101120000
+          VERSION_CLASS=$(basename "$LATEST_TARGET" .php)
+          DOCTRINE_VERSION="DoctrineMigrations\\${VERSION_CLASS}"
+
+          echo "Will rollback to: $DOCTRINE_VERSION"
+          echo "version=$DOCTRINE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "has_diff=true" >> "$GITHUB_OUTPUT"
+
       - name: Backup database before rollback
         run: make db.backup
 
       - name: Rollback Doctrine migrations
-        if: inputs.migration-version != ''
+        if: ${{ ! inputs.skip-migration-rollback && steps.detect-migration.outputs.has_diff == 'true' }}
         run: |
-          echo "Rolling back migrations to ${{ inputs.migration-version }}..."
+          echo "Rolling back migrations to ${{ steps.detect-migration.outputs.version }}..."
           docker exec -t $(docker ps --filter name="${STACK_NAME}_php" -q | head -1) \
-            bin/console doctrine:migrations:migrate "${{ inputs.migration-version }}" --no-interaction
+            bin/console doctrine:migrations:migrate "${{ steps.detect-migration.outputs.version }}" --no-interaction
 
       - name: Drain worker
         run: docker service scale ${STACK_NAME}_message_worker=0 || true

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -1,0 +1,70 @@
+name: Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to rollback to (e.g. v1.2.0)"
+        required: true
+        type: string
+      migration-version:
+        description: "Doctrine migration version to rollback to (e.g. DoctrineMigrations\\Version20240101120000). Leave empty to skip migration rollback."
+        required: false
+        type: string
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+
+    env:
+      DOCKER_HOST: ssh://${{ vars.SERVER_USERNAME }}@${{ vars.SERVER_HOST }}:${{ vars.SERVER_PORT }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      APP_SECRET: ${{ secrets.APP_SECRET }}
+      STACK_NAME: starter
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: 'true'
+
+      - name: Setup castor
+        uses: castor-php/setup-castor@v1.0.0
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p ${{ vars.SERVER_PORT }} ${{ vars.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Backup database before rollback
+        run: make db.backup
+
+      - name: Rollback Doctrine migrations
+        if: inputs.migration-version != ''
+        run: |
+          echo "Rolling back migrations to ${{ inputs.migration-version }}..."
+          docker exec -t $(docker ps --filter name="${STACK_NAME}_php" -q | head -1) \
+            bin/console doctrine:migrations:migrate "${{ inputs.migration-version }}" --no-interaction
+
+      - name: Drain worker
+        run: docker service scale ${STACK_NAME}_message_worker=0 || true
+
+      - name: Rollback main service
+        run: |
+          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:${{ inputs.tag }} ${STACK_NAME}_php"
+          castor barlito:castor:wait-php-container
+
+      - name: Rollback & restart worker
+        run: |
+          make docker.service.update args="--image ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}-worker:${{ inputs.tag }} ${STACK_NAME}_message_worker"
+          docker service scale ${STACK_NAME}_message_worker=1
+
+      - name: Smoke test
+        run: make smoke.test


### PR DESCRIPTION
## Summary
- Manual dispatch workflow (`workflow_dispatch`) for production deployment
- Two strategies via input toggle:
  - **Rolling update** (default): update Docker image → wait for healthy → run migrations → smoke test
  - **Full re-deploy**: undeploy stack entirely → redeploy from scratch
- SSH tunnel to remote Docker Swarm host
- Smoke test validates deployment success

## Required Configuration
**Secrets**: `SSH_PRIVATE_KEY`, `DOCKER_HUB_USERNAME`, `DOCKER_HUB_ACCESS_TOKEN`, `DB_PASSWORD`, `APP_SECRET`
**Vars**: `SERVER_HOST`, `SERVER_PORT`, `SERVER_USERNAME`

## Test plan
- [ ] Manual dispatch with rolling update works
- [ ] Manual dispatch with re-deploy works
- [ ] Smoke test catches broken deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)