### PR TITLE
feat: enhance Makefile with production, quality and npm rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Vars
 stack_name=starter
 app_container_id = $(shell docker ps --filter name="$(stack_name)_php" -q)
+db_container_id = $(shell docker ps --filter name="$(stack_name)_db" -q)
+prod_host=starter.example.com
+backup_path=/srv/$(stack_name)/backups
 
 # Config paths
 config_cs_fixer=vendor/barlito/utils/config/.php-cs-fixer.dist.php
@@ -9,3 +12,64 @@ config_phpmd=vendor/barlito/utils/config/phpmd.xml
 
 # Include all make rules from submodule
 include make/entrypoint.mk
+
+### Project-specific rules
+
+# PHPStan
+phpstan:
+	docker exec -t $(app_container_id) php -d "memory_limit=512M" vendor/bin/phpstan analyse
+
+phpstan.install:
+	docker exec -t $(app_container_id) bash -c "composer require --dev phpstan/phpstan phpstan/phpstan-symfony phpstan/phpstan-doctrine"
+
+# Aggregate quality check
+quality:
+	make cs_fixer.dry_run
+	make phpcs
+	make phpmd
+	make phpstan
+
+# Database backup (pg_dump, skipped if DB not running)
+db.backup:
+	@cid="$$(docker ps --filter name='$(stack_name)_db' -q | head -1)"; \
+	if [ -n "$$cid" ]; then \
+		ts="$$(date +%Y%m%d-%H%M%S)"; \
+		echo "Backup DB -> $(backup_path)/$(stack_name)-$$ts.dump (container $$cid)"; \
+		docker exec -t "$$cid" sh -c "pg_dump -U $(stack_name) -F c -d $(stack_name) -f /backups/$(stack_name)-$$ts.dump"; \
+	else \
+		echo "DB container not found, backup skipped (first deploy?)"; \
+	fi
+
+# Smoke test (curl GET / -> fail if non-2xx)
+smoke.test:
+	@echo "Smoke test https://$(prod_host)/..."
+	@curl -fsS -o /dev/null -w "  HTTP %{http_code}\n" https://$(prod_host)/ || (echo "Smoke test FAILED" && exit 1)
+	@echo "Smoke test OK"
+
+# Override deploy.prod: chains backup -> migrate -> smoke test
+deploy.prod:
+	make docker.deploy.prod
+	castor barlito:castor:wait-php-container
+	castor barlito:castor:wait-db-container
+	make db.backup
+	make doctrine.migrate
+	make smoke.test
+
+### npm rules (one-shot container)
+npm_exec_params=--rm -v $(shell pwd):/app -w /app
+npm_image=node:22
+
+npm.command:
+	docker run $(npm_exec_params) $(npm_image) npm $(args)
+
+npm.install:
+	make npm.command args="install"
+
+npm.build:
+	make npm.command args="run build"
+
+npm.dev:
+	make npm.command args="run dev"
+
+npm.watch:
+	make npm.command args="run watch"


### PR DESCRIPTION
## Summary
Add project-specific Make rules inspired by carapp and youl-coin-api:

- **PHPStan**: `make phpstan` (512MB memory) + `make phpstan.install`
- **Quality aggregate**: `make quality` runs all checks in sequence
- **DB backup**: `make db.backup` — pg_dump with timestamp, skips gracefully if DB not running
- **Smoke test**: `make smoke.test` — curl-based validation after deployment
- **Deploy prod**: `make deploy.prod` — full chain: build → wait → backup → migrate → smoke
- **npm rules**: `make npm.install`, `make npm.build`, `make npm.dev`, `make npm.watch` via one-shot Node container

## Test plan
- [ ] `make quality` runs all 4 checks sequentially
- [ ] `make db.backup` skips gracefully when no DB running
- [ ] `make smoke.test` fails on non-2xx responses
- [ ] `make npm.install` runs npm in a disposable container

🤖 Generated with [Claude Code](https://claude.com/claude-code)