### PR TITLE
ci: reusable test + code-quality example workflows (supersedes #8)

### DIFF
--- a/.github/workflow-examples/README.md
+++ b/.github/workflow-examples/README.md
@@ -1,0 +1,40 @@
+# Example CI workflows
+
+Ready-to-use GitHub Actions workflows for a project bootstrapped from this starter.
+They live here (and **not** in `.github/workflows/`) so they don't run on the starter
+repository itself — copy them into a real project to activate them.
+
+## What they do
+
+| File | Purpose |
+| ---- | ------- |
+| `entrypoint.yaml` | Runs on every `push`; fans out to the two reusable workflows below. |
+| `test.yaml` | Boots the CI stack, installs dependencies, migrates the test DB, runs **PHPUnit**. |
+| `code-quality.yaml` | Boots the CI stack and runs **php-cs-fixer** (dry-run), **phpcs**, **phpmd**. |
+
+Everything goes through the `make` targets from the [`php-make-rules`](https://github.com/barlito/php-make-rules)
+submodule, so the workflows are project-agnostic (no stack name hardcoded).
+
+## How to use
+
+1. Copy the three `*.yaml` files into your project's `.github/workflows/`:
+   ```bash
+   cp .github/workflow-examples/{entrypoint,test,code-quality}.yaml .github/workflows/
+   ```
+2. Make sure the targets they call exist (they ship with `php-make-rules`):
+   `docker.deploy.ci`, `composer.install`, `doctrine.migrate.ci`, `phpunit`,
+   `cs_fixer.dry_run`, `phpcs`, `phpmd`, `docker.undeploy.ci`.
+3. Install the quality toolchain once (configs come from `barlito/utils`):
+   ```bash
+   make package.barlito_utils.install
+   make cs_fixer.install
+   make phpcs.install
+   make phpmd.install
+   ```
+
+## Notes
+
+- **Docker Hub login is optional.** Set the `DOCKER_HUB_USERNAME` / `DOCKER_HUB_ACCESS_TOKEN`
+  repository secrets to avoid pull rate limits; the step is skipped when they're absent.
+- `code-quality.yaml` skips the database migration (the linters don't need it).
+- The default `GITHUB_TOKEN` is used for Composer's GitHub OAuth to avoid API rate limits.

--- a/.github/workflow-examples/README.md
+++ b/.github/workflow-examples/README.md
@@ -9,7 +9,7 @@ repository itself — copy them into a real project to activate them.
 | File | Purpose |
 | ---- | ------- |
 | `entrypoint.yaml` | Runs on every `push`; fans out to the two reusable workflows below. |
-| `test.yaml` | Boots the CI stack, installs dependencies, migrates the test DB, runs **PHPUnit**. |
+| `test.yaml` | Boots the CI stack, installs dependencies, migrates the test DB, runs **PHPUnit** and **Behat**. |
 | `code-quality.yaml` | Boots the CI stack and runs **php-cs-fixer** (dry-run), **phpcs**, **phpmd**. |
 
 Everything goes through the `make` targets from the [`php-make-rules`](https://github.com/barlito/php-make-rules)
@@ -23,7 +23,8 @@ submodule, so the workflows are project-agnostic (no stack name hardcoded).
    ```
 2. Make sure the targets they call exist (they ship with `php-make-rules`):
    `docker.deploy.ci`, `composer.install`, `doctrine.migrate.ci`, `phpunit`,
-   `cs_fixer.dry_run`, `phpcs`, `phpmd`, `docker.undeploy.ci`.
+   `behat.install`, `behat.init`, `behat`, `cs_fixer.dry_run`, `phpcs`, `phpmd`,
+   `docker.undeploy.ci`.
 3. Install the quality toolchain once (configs come from `barlito/utils`):
    ```bash
    make package.barlito_utils.install
@@ -38,3 +39,5 @@ submodule, so the workflows are project-agnostic (no stack name hardcoded).
   repository secrets to avoid pull rate limits; the step is skipped when they're absent.
 - `code-quality.yaml` skips the database migration (the linters don't need it).
 - The default `GITHUB_TOKEN` is used for Composer's GitHub OAuth to avoid API rate limits.
+- Behat is optional: drop the three `Behat` steps in `test.yaml` if your project has no functional suite.
+- Actions are pinned to `checkout@v6` / `cache@v5` / `setup-castor@v1.0.0`.

--- a/.github/workflow-examples/code-quality.yaml
+++ b/.github/workflow-examples/code-quality.yaml
@@ -1,0 +1,56 @@
+name: Code Quality Workflow
+
+on: workflow_call
+
+jobs:
+  code_quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Setup castor
+        uses: castor-php/setup-castor@v1.0.0
+
+      # Optional: avoids Docker Hub pull rate limits. Skipped if the secret is absent.
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKER_HUB_USERNAME }}
+        if: env.DOCKERHUB_USER != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/files
+          key: composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: Deploy stack (CI)
+        run: USER_ID=$(id -u) GROUP_ID=$(id -g) make docker.deploy.ci
+
+      - name: Wait for container
+        run: castor barlito:castor:wait-php-container
+
+      - name: Configure Composer GitHub token
+        run: make composer.command args="config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install dependencies
+        run: make composer.install
+
+      - name: PHP CS Fixer (dry-run)
+        run: make cs_fixer.dry_run
+
+      - name: PHP CodeSniffer
+        run: make phpcs
+
+      - name: PHP Mess Detector
+        run: make phpmd
+
+      - name: Undeploy stack
+        if: always()
+        run: make docker.undeploy.ci

--- a/.github/workflow-examples/code-quality.yaml
+++ b/.github/workflow-examples/code-quality.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/files
           key: composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflow-examples/entrypoint.yaml
+++ b/.github/workflow-examples/entrypoint.yaml
@@ -1,0 +1,18 @@
+name: CI
+
+on: push
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Static analysis / coding standards (PHP CS Fixer, PHPCS, PHPMD)
+  code-quality:
+    uses: ./.github/workflows/code-quality.yaml
+    secrets: inherit
+
+  # Test suite (PHPUnit)
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets: inherit

--- a/.github/workflow-examples/test.yaml
+++ b/.github/workflow-examples/test.yaml
@@ -1,0 +1,55 @@
+name: Tests Workflow
+
+on: workflow_call
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Setup castor
+        uses: castor-php/setup-castor@v1.0.0
+
+      # Optional: avoids Docker Hub pull rate limits. Skipped if the secret is absent.
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKER_HUB_USERNAME }}
+        if: env.DOCKERHUB_USER != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/files
+          key: composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: Deploy stack (CI)
+        run: USER_ID=$(id -u) GROUP_ID=$(id -g) make docker.deploy.ci
+
+      - name: Wait for containers
+        run: |
+          castor barlito:castor:wait-php-container
+          castor barlito:castor:wait-db-container
+
+      - name: Configure Composer GitHub token
+        run: make composer.command args="config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install dependencies
+        run: make composer.install
+
+      - name: Create & migrate the test database
+        run: make doctrine.migrate.ci
+
+      - name: Run PHPUnit
+        run: make phpunit
+
+      - name: Undeploy stack
+        if: always()
+        run: make docker.undeploy.ci

--- a/.github/workflow-examples/test.yaml
+++ b/.github/workflow-examples/test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/files
           key: composer-${{ hashFiles('**/composer.lock') }}
@@ -49,6 +49,16 @@ jobs:
 
       - name: Run PHPUnit
         run: make phpunit
+
+      # Behat (functional tests). Drop these three steps if your project has no Behat suite.
+      - name: Install Behat
+        run: make behat.install
+
+      - name: Init Behat
+        run: make behat.init
+
+      - name: Run Behat
+        run: make behat
 
       - name: Undeploy stack
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # barlito/php-starter
 
-[![CI](https://github.com/barlito/php-starter/actions/workflows/entrypoint.yaml/badge.svg?branch=master)](https://github.com/barlito/php-starter/actions/workflows/entrypoint.yaml)
+[![CI](https://github.com/barlito/php-starter/actions/workflows/symfony_starter.yaml/badge.svg?branch=master)](https://github.com/barlito/php-starter/actions/workflows/symfony_starter.yaml)
 
 Symfony starter template with FrankenPHP, Docker Swarm, and a full CI/CD pipeline.
 
@@ -85,18 +85,21 @@ make npm.watch              # Watch mode
 
 ## CI/CD
 
-Workflows in `.github/workflows/`:
+Active workflows in `.github/workflows/`:
 
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
-| `entrypoint.yaml` | Push | Orchestrates quality + tests in parallel |
-| `code-quality.yaml` | Called | CS Fixer, PHPCS, PHPMD |
-| `test.yaml` | Called | PHPUnit, Behat |
+| `symfony_starter.yaml` | Push | Validates the starter itself (bootstrap + PHPUnit/Behat) |
 | `security.yaml` | Called + Weekly cron | Trivy image vulnerability scan |
 | `release.yaml` | GitHub Release | Build + push Docker images |
 | `deploy.yaml` | Manual | Rolling update or full re-deploy |
 | `rollback.yaml` | Manual | Rollback to tag + optional migration revert |
 | `dependabot-auto-merge.yaml` | PR | Auto-merge patch updates |
+
+Copy-paste examples for real projects live in [`.github/workflow-examples/`](.github/workflow-examples/)
+(they don't run on the starter): a reusable `entrypoint` that fans out to `test`
+(PHPUnit + Behat) and `code-quality` (php-cs-fixer / phpcs / phpmd). See that folder's
+README for details.
 
 ## Docker Targets
 


### PR DESCRIPTION
Consolidates the two CI-refactor PRs (**#8** + this one) into a single, cleaner approach.

## Approach
- The **starter keeps validating itself** via `.github/workflows/symfony_starter.yaml` (fixed in #19).
- Reusable **example** workflows live in `.github/workflow-examples/` — they do not run on the starter repo, they are copied into real projects.

## Content (mix of #8 and #16)
- Modular `entrypoint` -> `test` + `code-quality` reusable workflows (from #8 design).
- Robustness from #16: `wait-php/db-container`, test DB migration, optional Docker Hub login.
- From #8: actions bumped to `checkout@v6` / `cache@v5`, and **Behat** added to `test.yaml`.
- README documenting usage.

Closes #8.