### PR TITLE
chore: bump to PHP 8.4 and Postgres 18 example

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1-php8.3 AS frankenphp_upstream
+FROM dunglas/frankenphp:1-php8.4 AS frankenphp_upstream
 
 FROM frankenphp_upstream AS frankenphp_base
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A production-ready Symfony starter template featuring FrankenPHP, Docker Swarm d
 
 ## Features
 
-- **FrankenPHP** (PHP 8.3): Modern PHP application server built on Caddy
+- **FrankenPHP** (PHP 8.4): Modern PHP application server built on Caddy
 - **Docker Swarm**: Production-ready orchestration with Traefik integration
 - **Make + Castor**: Dual task automation system for flexibility
 - **Code Quality Tools**: PHP CS Fixer, PHPCS, PHPMD pre-configured
@@ -230,7 +230,7 @@ The project uses both **Make** and **Castor** for task automation:
 
 ### Docker Stack
 
-- **FrankenPHP**: Modern PHP 8.3 server based on Caddy with live reload in dev mode
+- **FrankenPHP**: Modern PHP 8.4 server based on Caddy with live reload in dev mode
 - **Docker Swarm**: Orchestration for development (uses `docker stack deploy`)
 - **Traefik Integration**: HTTP/HTTPS routing via external `traefik_traefik_proxy` network
 - **Volumes**: Persistent storage for Caddy data and configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,12 @@ services:
 #            - starter_internal
 
 #    db:
-#        image: postgres:16
+#        image: postgres:18-alpine
 #        environment:
 #            POSTGRES_PASSWORD: root
 #        volumes:
-#            - starter_db_data:/var/lib/postgresql/data:rw
+#            # Postgres 18+ stores data in /var/lib/postgresql (not /data anymore)
+#            - starter_db_data:/var/lib/postgresql:rw
 #        networks:
 #            - starter_internal
 


### PR DESCRIPTION
Modernise the template:

- **FrankenPHP** base image **PHP 8.3 → 8.4**.
- docker-compose `db` example: **postgres 16 → 18-alpine**, and mount the volume at **`/var/lib/postgresql`** — PG18+ images moved `PGDATA` out of `/var/lib/postgresql/data`, so the old mount path breaks.
- README updated to PHP 8.4.

Validated downstream on dog-help-scheduler (PHP 8.4.21 / PostgreSQL 18.4 / Symfony 8.1).