### PR TITLE
chore(claude): hook Claude Code qualité au commit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); if printf '%s' \"$INPUT\" | grep -qE '\"command\"[[:space:]]*:[[:space:]]*\"git commit'; then set -o pipefail; { make fix_style && git diff --cached --name-only -z | xargs -0 -r git add -- && make check_style; } 2>&1 | grep -vE 'overriding recipe for target|ignoring old recipe for target'; else true; fi",
+            "timeout": 180,
+            "statusMessage": "Auto-fix + code quality (cs-fixer, rector, phpcs, phpmd, phpstan)..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Ajoute `.claude/settings.json` au starter : un hook `PreToolUse` (Bash) limité aux `git commit` qui lance `make fix_style` → re-stage les fichiers corrigés → `make check_style`. Ainsi tout projet bootstrappé depuis le starter hérite du garde-fou qualité au commit, côté Claude Code.

Détails d'implémentation :
- scope `git commit` via filtre sur la commande lue dans le JSON du hook (le champ `if` natif de Claude Code ne filtrait pas → lançait le check sur toutes les commandes) ;
- sortie nettoyée des warnings make (`overriding recipe…`) pour que l'erreur réelle soit lisible ;
- code d'erreur réel préservé via `set -o pipefail` (le commit est bien bloqué si la qualité échoue).

Issu de la mise au point faite sur carapp.