### PR TITLE
fix(ci): match FrankenPHP server header in health check

### DIFF
--- a/.github/workflows/symfony_starter.yaml
+++ b/.github/workflows/symfony_starter.yaml
@@ -35,7 +35,7 @@ jobs:
         run: make package.barlito_utils.install
 
       - name: Check app works well
-        run: "curl -I http://localhost:8081/ | grep -q 'Server: Caddy'"
+        run: "curl -I http://localhost:8081/ | grep -qi 'Server: FrankenPHP'"
 
       - name: Setup github token
         run: make composer.command args="config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Problème

Le check *Check app works well* échoue sur **master** et sur **les 14 PR ouvertes** depuis la migration FrankenPHP.

Reproduit localement :
```
curl -I http://localhost:8081/  →  Server: FrankenPHP Caddy
CI teste                        →  grep -q 'Server: Caddy'   ❌
```
La chaîne `Server: Caddy` n'existe plus (header devenu `Server: FrankenPHP Caddy`), donc le grep sort en erreur et fait échouer tout le job.

## Fix

`grep -qi 'Server: FrankenPHP'` — matche le nouveau header, insensible à la casse.

Une fois mergé, rebaser les PR ouvertes pour repasser leur CI au vert.