### PR TITLE
chore(phpstan): raise analysis level to 8

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 8
     paths:
         - src/
     excludePaths:


### PR DESCRIPTION
Bumps PHPStan from level 6 to **level 8**.

Rationale: the starter has no `src/` code yet, so a stricter level is free and raises the quality bar inherited by bootstrapped projects. Level 8 is the standard 'strict' tier; `max` (currently level 10) is available if you want the strictest set.