### PR TITLE
fix(prod): bind-mount host backups dir for db service

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -66,6 +66,8 @@ services:
             PGTZ: Europe/Paris
         volumes:
             - starter_db_data:/var/lib/postgresql:rw
+            # Host path for `make db.backup` (pg_dump writes to /backups inside the container)
+            - /srv/starter/backups:/backups
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U starter"]
             interval: 10s


### PR DESCRIPTION
## Problem
`make db.backup` runs before every prod deploy and rollback and makes `pg_dump` write to `/backups` **inside** the db container. But `docker-compose-prod.yml` only mounted `starter_db_data:/var/lib/postgresql` — nothing at `/backups`. So the dump failed, and since the deploy/rollback chain calls `db.backup` without `|| true`, a failed backup **aborted the whole deploy** (and in rollback, before any recovery).

## Fix
Mount `/srv/starter/backups:/backups` on the db service, mirroring the `carapp` prod setup. The Makefile already targets `/backups`, so no recipe change needed.

Found during the post-merge review pass. (Not fixing `DOCKER_IMAGE` default or deploy tag default — both are intentional placeholders for the consuming project.)